### PR TITLE
Upload image chunks in parallel to Swift

### DIFF
--- a/glance_store/_drivers/swift/store.py
+++ b/glance_store/_drivers/swift/store.py
@@ -19,6 +19,7 @@ import hashlib
 import logging
 import math
 
+from concurrent import futures
 from keystoneauth1.access import service_catalog as keystone_sc
 from keystoneauth1 import identity as ks_identity
 from keystoneauth1 import session as ks_session
@@ -40,6 +41,7 @@ from glance_store._drivers.swift import buffered
 from glance_store._drivers.swift import connection_manager
 from glance_store._drivers.swift import utils as sutils
 from glance_store import capabilities
+from glance_store.common import utils as cutils
 from glance_store import driver
 from glance_store import exceptions
 from glance_store.i18n import _, _LE, _LI
@@ -51,6 +53,7 @@ LOG = logging.getLogger(__name__)
 DEFAULT_CONTAINER = 'glance'
 DEFAULT_LARGE_OBJECT_SIZE = 5 * units.Ki  # 5GB
 DEFAULT_LARGE_OBJECT_CHUNK_SIZE = 200  # 200M
+DEFAULT_THREAD_POOL_SIZE = 1                # 1 thread
 ONE_MB = units.k * units.Ki  # Here we used the mixed meaning of MB
 
 _SWIFT_OPTS = [
@@ -243,6 +246,7 @@ Possible values:
 
 Related options:
     * ``swift_store_large_object_chunk_size``
+    * ``swift_store_thread_pool_size``
 
 """),
     cfg.IntOpt('swift_store_large_object_chunk_size',
@@ -266,6 +270,23 @@ Possible values:
 
 Related options:
     * ``swift_store_large_object_size``
+    * ``swift_store_thread_pool_size``
+
+"""),
+    cfg.IntOpt('swift_store_thread_pool_size',
+               default=DEFAULT_THREAD_POOL_SIZE,
+               help="""
+The number of threads in the pool to perform a multipart upload in Swift.
+
+This configuration option takes the number of threads in the pool when
+performing a Multipart Upload.
+
+Possible values:
+    * Any positive integer value
+
+Related Options:
+    * ``swift_store_large_object_size``
+    * ``swift_store_large_object_chunk_size``
 
 """),
     cfg.BoolOpt('swift_store_create_container_on_put', default=False,
@@ -475,6 +496,51 @@ Related options:
 
 """),
 ]
+
+
+class UploadPart(object):
+    """The class for the upload part."""
+    def __init__(self, fp, partnum, chunks):
+        self.partnum = partnum
+        self.fp = fp
+        self.size = 0
+        self.chunks = chunks
+        self.etag = {}
+        self.success = True
+
+
+def run_upload(manager, location, part):
+
+    pnum = part.partnum
+    bsize = part.chunks
+    chunk_name = "%s-%05d" % (location.obj, pnum)
+    LOG.debug("Uploading upload part in Swift partnum=%(pnum)d, "
+              "size=%(bsize)d, key=%(chunk_name)s",
+              {'pnum': pnum, 'bsize': bsize, 'chunk_name': chunk_name})
+    try:
+        chunk_etag = \
+            manager.get_connection().put_object(
+                location.container,
+                chunk_name, part.fp,
+                content_length=bsize)
+        part.etag[pnum] = chunk_etag
+        part.size = bsize
+    except Exception:
+        LOG.error(_("Error during chunked upload to backend, deleting stale "
+                    "chunks."))
+        part.success = False
+    finally:
+        part.fp.close()
+    msg = (
+        "Wrote chunk %(chunk_name)s with id %(chunk_id)d of length "
+        "%(bytes_read)d to Swift returning MD5 of content: %(chunk_etag)s" % {
+            'chunk_name': chunk_name,
+            'chunk_id': pnum,
+            'bytes_read': bsize,
+            'chunk_etag': chunk_etag
+        }
+    )
+    LOG.debug(msg)
 
 
 def swift_retry_iter(resp_iter, length, store, location, manager):
@@ -799,6 +865,16 @@ class BaseStore(driver.Store):
         self.large_object_size = _obj_size * ONE_MB
         _chunk_size = self._option_get('swift_store_large_object_chunk_size')
         self.large_object_chunk_size = _chunk_size * ONE_MB
+        self.swift_store_thread_pool_size = self._option_get(
+            'swift_store_thread_pool_size')
+        if self.swift_store_thread_pool_size <= 0:
+            msg = _(
+                "swift_store_thread_pool_size must be a positive integer. %s"
+            ) % self.swift_store_thread_pool_size
+            LOG.error(msg)
+            raise exceptions.BadStoreConfiguration(
+                store_name="swift", reason=msg
+            )
         self.admin_tenants = glance_conf.swift_store_admin_tenants
         self.region = glance_conf.swift_store_region
         self.service_type = glance_conf.swift_store_service_type
@@ -901,14 +977,14 @@ class BaseStore(driver.Store):
 
     def _delete_stale_chunks(self, connection, container, chunk_list):
         for chunk in chunk_list:
-            LOG.debug("Deleting chunk %s" % chunk)
+            LOG.debug("Deleting chunk %s" % chunk.name)
             try:
-                connection.delete_object(container, chunk)
+                connection.delete_object(container, chunk.name)
             except Exception:
                 msg = _("Failed to delete orphaned chunk "
                         "%(container)s/%(chunk)s")
                 LOG.exception(msg % {'container': container,
-                                     'chunk': chunk})
+                                     'chunk': chunk.name})
 
     @driver.back_compat_add
     @capabilities.check
@@ -936,104 +1012,56 @@ class BaseStore(driver.Store):
         # initialize a manager with re-auth if image need to be splitted
         need_chunks = (image_size == 0) or (
             image_size >= self.large_object_size)
+
         with self.get_manager(location, context,
                               allow_reauth=need_chunks) as manager:
-
             self._create_container_if_missing(location.container,
                                               manager.get_connection())
-
             LOG.debug("Adding image object '%(obj_name)s' "
                       "to Swift" % dict(obj_name=location.obj))
             try:
+                checksum = hashlib.md5()
                 if not need_chunks:
                     # Image size is known, and is less than large_object_size.
                     # Send to Swift with regular PUT.
-                    checksum = hashlib.md5()
                     reader = ChunkReader(image_file, checksum,
                                          os_hash_value, image_size,
                                          verifier=verifier)
                     obj_etag = manager.get_connection().put_object(
                         location.container, location.obj,
                         reader, content_length=image_size)
+
                 else:
                     # Write the image into Swift in chunks.
-                    chunk_id = 1
-                    if image_size > 0:
-                        total_chunks = str(int(
-                            math.ceil(float(image_size) /
-                                      float(self.large_object_chunk_size))))
-                    else:
-                        # image_size == 0 is when we don't know the size
-                        # of the image. This can occur with older clients
-                        # that don't inspect the payload size.
-                        LOG.debug("Cannot determine image size because it is "
-                                  "either not provided in the request or "
-                                  "chunked-transfer encoding is used. "
-                                  "Adding image as a segmented object to "
-                                  "Swift.")
-                        total_chunks = '?'
+                    total_size, plist = self._upload_chunks(
+                        image_file,
+                        checksum,
+                        os_hash_value,
+                        manager,
+                        location,
+                        verifier,
+                    )
+                    success = True
+                    for part in plist:
+                        if not part.success:
+                            success = False
+                            break
 
-                    checksum = hashlib.md5()
-                    written_chunks = []
-                    combined_chunks_size = 0
-                    while True:
-                        chunk_size = self.large_object_chunk_size
-                        if image_size == 0:
-                            content_length = None
-                        else:
-                            left = image_size - combined_chunks_size
-                            if left == 0:
-                                break
-                            if chunk_size > left:
-                                chunk_size = left
-                            content_length = chunk_size
+                    if not success:
+                        # Delete orphaned segments from swift backend
+                        with excutils.save_and_reraise_exception():
+                            LOG.error(_("Error during chunked upload "
+                                        "to backend, deleting stale "
+                                        "chunks."))
+                            self._delete_stale_chunks(
+                                manager.get_connection(),
+                                location.container,
+                                plist)
 
-                        chunk_name = "%s-%05d" % (location.obj, chunk_id)
-
-                        with self.reader_class(
-                                image_file, checksum, os_hash_value,
-                                chunk_size, verifier,
-                                backend_group=self.backend_group) as reader:
-                            if reader.is_zero_size is True:
-                                LOG.debug('Not writing zero-length chunk.')
-                                break
-
-                            try:
-                                chunk_etag = \
-                                    manager.get_connection().put_object(
-                                        location.container,
-                                        chunk_name, reader,
-                                        content_length=content_length)
-                                written_chunks.append(chunk_name)
-                            except Exception:
-                                # Delete orphaned segments from swift backend
-                                with excutils.save_and_reraise_exception():
-                                    LOG.error(_("Error during chunked upload "
-                                                "to backend, deleting stale "
-                                                "chunks."))
-                                    self._delete_stale_chunks(
-                                        manager.get_connection(),
-                                        location.container,
-                                        written_chunks)
-
-                            bytes_read = reader.bytes_read
-                            msg = ("Wrote chunk %(chunk_name)s (%(chunk_id)d/"
-                                   "%(total_chunks)s) of length %(bytes_read)"
-                                   "d to Swift returning MD5 of content: "
-                                   "%(chunk_etag)s" %
-                                   {'chunk_name': chunk_name,
-                                    'chunk_id': chunk_id,
-                                    'total_chunks': total_chunks,
-                                    'bytes_read': bytes_read,
-                                    'chunk_etag': chunk_etag})
-                            LOG.debug(msg)
-
-                        chunk_id += 1
-                        combined_chunks_size += bytes_read
                     # In the case we have been given an unknown image size,
                     # set the size to the total size of the combined chunks.
                     if image_size == 0:
-                        image_size = combined_chunks_size
+                        image_size = total_size
 
                     # Now we write the object manifest in X-Object-Manifest
                     # header as defined for Dynamic Large Objects (DLO) Mode.
@@ -1080,6 +1108,37 @@ class BaseStore(driver.Store):
                        % encodeutils.exception_to_unicode(e))
                 LOG.error(msg)
                 raise glance_store.BackendException(msg)
+
+    def _upload_chunks(self, image_file, checksum, os_hash_value,
+                       manager, location, verifier):
+        chunk_id = 0
+        total_size = 0
+        plist = []
+
+        it = cutils.chunkreadable(image_file, self.large_object_chunk_size)
+        workers = self.swift_store_thread_pool_size
+        futs = []
+        with futures.ThreadPoolExecutor(max_workers=workers) as executor:
+            for write_chunk in it:
+                os_hash_value.update(write_chunk)
+                checksum.update(write_chunk)
+                if verifier:
+                    verifier.update(write_chunk)
+                fp = six.BytesIO(write_chunk)
+                fp.seek(0)
+                part_size = len(write_chunk)
+                part = UploadPart(fp, chunk_id + 1, part_size)
+                futs.append(executor.submit(
+                    run_upload, manager, location, part))
+                plist.append(part)
+                total_size += part_size
+                chunk_id += 1
+
+        # Wait until all futures are complete
+        for fut in futures.as_completed(futs):
+            pass
+
+        return total_size, plist
 
     @capabilities.check
     def delete(self, location, connection=None, context=None):

--- a/glance_store/tests/unit/test_opts.py
+++ b/glance_store/tests/unit/test_opts.py
@@ -122,6 +122,7 @@ class OptsTestCase(base.StoreBaseTest):
             'swift_store_key',
             'swift_store_large_object_chunk_size',
             'swift_store_large_object_size',
+            'swift_store_thread_pool_size',
             'swift_store_multi_tenant',
             'swift_store_multiple_containers_seed',
             'swift_store_region',

--- a/glance_store/tests/unit/test_swift_store.py
+++ b/glance_store/tests/unit/test_swift_store.py
@@ -773,7 +773,7 @@ class SwiftTests(object):
             self.store.large_object_size = orig_max_size
 
         # Confirm verifier update called expected number of times
-        self.assertEqual(2 * swift_size / custom_size,
+        self.assertEqual(swift_size / custom_size,
                          verifier.update.call_count)
 
         # define one chunk of the contents
@@ -781,15 +781,10 @@ class SwiftTests(object):
 
         # confirm all expected calls to update have occurred
         calls = [mock.call(swift_contents_piece),
-                 mock.call(b''),
                  mock.call(swift_contents_piece),
-                 mock.call(b''),
                  mock.call(swift_contents_piece),
-                 mock.call(b''),
                  mock.call(swift_contents_piece),
-                 mock.call(b''),
-                 mock.call(swift_contents_piece),
-                 mock.call(b'')]
+                 mock.call(swift_contents_piece)]
         verifier.update.assert_has_calls(calls)
 
     @mock.patch('glance_store._drivers.swift.utils'

--- a/glance_store/tests/unit/test_swift_store_multibackend.py
+++ b/glance_store/tests/unit/test_swift_store_multibackend.py
@@ -750,7 +750,7 @@ class SwiftTests(object):
             self.store.large_object_size = orig_max_size
 
         # Confirm verifier update called expected number of times
-        self.assertEqual(2 * swift_size / custom_size,
+        self.assertEqual(swift_size / custom_size,
                          verifier.update.call_count)
 
         # define one chunk of the contents
@@ -758,15 +758,10 @@ class SwiftTests(object):
 
         # confirm all expected calls to update have occurred
         calls = [mock.call(swift_contents_piece),
-                 mock.call(b''),
                  mock.call(swift_contents_piece),
-                 mock.call(b''),
                  mock.call(swift_contents_piece),
-                 mock.call(b''),
                  mock.call(swift_contents_piece),
-                 mock.call(b''),
-                 mock.call(swift_contents_piece),
-                 mock.call(b'')]
+                 mock.call(swift_contents_piece)]
         verifier.update.assert_has_calls(calls)
 
     @mock.patch('glance_store._drivers.swift.utils'


### PR DESCRIPTION
    PUT operation for images is slow due to synchronous chunks uploading.
    To speed up this operation, the patch uses a `ThreadPoolExecutor`
    to split the chunk to be uploaded.