### PR TITLE
Fix missing log context

### DIFF
--- a/lower-constraints.txt
+++ b/lower-constraints.txt
@@ -40,6 +40,7 @@ os-client-config==1.29.0
 oslo.concurrency==3.26.0
 oslo.config==5.2.0
 oslo.i18n==3.15.3
+oslo.log==4.4.0
 oslo.privsep==1.23.0
 oslo.rootwrap==5.8.0
 oslo.serialization==2.18.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 # process, which may cause wedges in the gate later.
 oslo.config>=5.2.0 # Apache-2.0
 oslo.i18n>=3.15.3 # Apache-2.0
+oslo.log>=4.4.0 # Apache-2.0
 oslo.serialization!=2.19.1,>=2.18.0 # Apache-2.0
 oslo.utils>=3.33.0 # Apache-2.0
 oslo.concurrency>=3.26.0 # Apache-2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,6 +70,7 @@ swift =
 cinder =
   python-cinderclient>=4.1.0 # Apache-2.0
   os-brick>=2.6.0 # Apache-2.0
+  oslo.log>=4.4.0 # Apache-2.0
   oslo.rootwrap>=5.8.0 # Apache-2.0
   oslo.privsep>=1.23.0 # Apache-2.0
 s3 =


### PR DESCRIPTION
After the feature was submitted in the separate thread it's losing
the request context. To prevent it we need to use 'oslo_log' library
instead of built-in logging and explicitly pass the context into
the submitted future.

* Also remove unused import `math` as we don't need it anymore