### PR TITLE
Fix Swift driver size validation timing in chunked uploads

### DIFF
--- a/glance_store/_drivers/swift/store.py
+++ b/glance_store/_drivers/swift/store.py
@@ -970,22 +970,23 @@ class BaseStore(driver.Store):
                         else:
                             content_length = chunk_size
                         chunk_name = "%s-%05d" % (location.obj, chunk_id)
-                        # Check if actual data exceeds the specified
-                        # image_size
-                        if (image_size != 0 and
-                                combined_chunks_size > image_size):
-                            raise glance_store.Invalid(
-                                _("Size exceeds: expected "
-                                  "%(expected)d "
-                                  "bytes, got %(actual)d bytes") %
-                                {'expected': image_size,
-                                 'actual': combined_chunks_size})
 
                         with self.reader_class(
                                 image_file, checksum, os_hash_value,
                                 chunk_size, verifier,
                                 backend_group=self.backend_group) as reader:
                             if reader.is_zero_size is True:
+                                # EOF reached - validate size immediately
+                                if (image_size != 0 and
+                                        combined_chunks_size != image_size):
+                                    message = (_("Size mismatch: expected "
+                                                 "%(expected)d "
+                                                 "bytes, got %(actual)d "
+                                                 "bytes") %
+                                               {'expected': image_size,
+                                                'actual':
+                                                    combined_chunks_size})
+                                    raise glance_store.Invalid(message=message)
                                 LOG.debug('Not writing zero-length chunk.')
                                 break
 
@@ -1021,6 +1022,16 @@ class BaseStore(driver.Store):
 
                         chunk_id += 1
                         combined_chunks_size += bytes_read
+
+                        # Check if actual data exceeds the specified
+                        # image_size after reading and updating the size
+                        if (image_size != 0 and
+                                combined_chunks_size > image_size):
+                            raise glance_store.Invalid(
+                                _("Size exceeds: expected %(expected)d "
+                                  "bytes, got %(actual)d bytes") %
+                                {'expected': image_size,
+                                 'actual': combined_chunks_size})
 
                     # Validate total size after all chunks are uploaded
                     if image_size != 0 and combined_chunks_size != image_size:

--- a/releasenotes/notes/fix-swift-chunked-upload-size-validation-08f33e3d77a05643.yaml
+++ b/releasenotes/notes/fix-swift-chunked-upload-size-validation-08f33e3d77a05643.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    `Bug #2136857 <https://bugs.launchpad.net/glance-store/+bug/2136857>`_:
+    Swift: Fixed chunked upload size validation timing. Size-exceeds is now
+    detected in the same iteration, and early EOF is reported immediately
+    instead of causing long timeouts.


### PR DESCRIPTION
Move size validation check to after reading chunks and updating combined_chunks_size, and add immediate EOF validation. This prevents size mismatches from being detected one iteration late and avoids 90s timeouts when EOF is reached before expected size.

Existing unit tests already cover both failure scenarios and use the chunked upload path, so no new tests are required.

Closes-Bug: #2136857

Change-Id: I729893663bcdf630f17f6b140faa1d9e3e9b449d