### PR TITLE
Fix final chunk's content_length for image uploads.

### DIFF
--- a/glance_store/_drivers/swift/store.py
+++ b/glance_store/_drivers/swift/store.py
@@ -968,7 +968,8 @@ class BaseStore(driver.Store):
                         if image_size == 0:
                             content_length = None
                         else:
-                            content_length = chunk_size
+                            left = image_size - combined_chunks_size
+                            content_length = min(chunk_size, left)
                         chunk_name = "%s-%05d" % (location.obj, chunk_id)
 
                         with self.reader_class(


### PR DESCRIPTION
When uploading an image with a known size, the final chunk's `content_length` was incorrectly set to the full chunk_size instead of the actual remaining bytes due to commit
https://github.com/openstack/glance_store/commit/7b5817aed476fe6c79e04782fea129dd487d456a

This may cause Swift to wait for data that will never arrive, leading to idle timeouts and client disconnection errors. The fix passes the last chunks actual remaining bytes as `content_length`.

Change-Id: I80eb58b484c0561300eccee729782d1f61cd30df