### PR TITLE
swift: fix MultiTentantStore url_prefix

### DIFF
--- a/glance_store/_drivers/swift/store.py
+++ b/glance_store/_drivers/swift/store.py
@@ -1487,24 +1487,30 @@ class SingleTenantStore(BaseStore):
 class MultiTenantStore(BaseStore):
     EXAMPLE_URL = "swift://<SWIFT_URL>/<CONTAINER>/<FILE>"
 
-    def _get_endpoint(self, context):
+    def configure_add(self):
         if self.backend_group:
-            self.container = getattr(self.conf,
-                                     self.backend_group).swift_store_container
+            self.container = getattr(
+                self.conf, self.backend_group).swift_store_container
         else:
             self.container = self.conf.glance_store.swift_store_container
+        self.scheme = None
+        self.storage_url = None
+        self._storage_netloc = None
+        if self.backend_group:
+            self._set_url_prefix()
 
-        if context is None:
-            reason = _("Multi-tenant Swift storage requires a context.")
-            raise exceptions.BadStoreConfiguration(store_name="swift",
-                                                   reason=reason)
-        if context.service_catalog is None:
-            reason = _("Multi-tenant Swift storage requires "
-                       "a service catalog.")
-            raise exceptions.BadStoreConfiguration(store_name="swift",
-                                                   reason=reason)
+    def _get_endpoint(self, context=None):
         self.storage_url = self.conf_endpoint
         if not self.storage_url:
+            if context is None:
+                reason = _("Multi-tenant Swift storage requires a context.")
+                raise exceptions.BadStoreConfiguration(
+                    store_name="swift", reason=reason)
+            if context.service_catalog is None:
+                reason = _("Multi-tenant Swift storage requires "
+                           "a service catalog.")
+                raise exceptions.BadStoreConfiguration(
+                    store_name="swift", reason=reason)
             catalog = keystone_sc.ServiceCatalogV2(context.service_catalog)
             self.storage_url = catalog.url_for(service_type=self.service_type,
                                                region_name=self.region,
@@ -1514,6 +1520,8 @@ class MultiTenantStore(BaseStore):
             self.scheme = 'swift+http'
         else:
             self.scheme = 'swift+https'
+
+        self._storage_netloc = urllib.parse.urlsplit(self.storage_url).netloc
 
         return self.storage_url
 
@@ -1570,9 +1578,37 @@ class MultiTenantStore(BaseStore):
                              backend_group=self.backend_group)
 
     def _set_url_prefix(self, context=None):
-        ep = self._get_endpoint(context)
-        self._url_prefix = "%s://%s:%s_" % (
-            self.scheme, ep, self.container)
+        # Attempt to resolve self._storage_netloc and self.scheme
+        if not self._storage_netloc or not self.scheme:
+            try:
+                self._get_endpoint(context)
+            except exceptions.BadStoreConfiguration:
+                LOG.debug("Cannot set url_prefix for multi-tenant Swift "
+                          "store. Endpoint unknown.")
+                return
+        self._url_prefix = f"{self.scheme}://{self._storage_netloc}/"
+
+    def matches_uri(self, uri, context=None):
+        # Attempt to resolve self._storage_netloc and self.scheme if unset
+        if not self._storage_netloc or not self.scheme:
+            try:
+                self._get_endpoint(context)
+            except exceptions.BadStoreConfiguration:
+                pass
+        # Validate scheme
+        parsed = urllib.parse.urlsplit(uri)
+        if self.scheme and parsed.scheme != self.scheme:
+            return False
+        if not self.scheme and parsed.scheme not in self.get_schemes():
+            return False
+        # Validate netloc
+        if self._storage_netloc and parsed.netloc != self._storage_netloc:
+            return False
+        # Validate the container prefix in the second-to-last path segment
+        parts = parsed.path.strip('/').split('/')
+        if len(parts) >= 2:
+            return parts[-2].startswith(self.container + '_')
+        return False
 
     def get_connection(self, location, context=None):
         return swiftclient.Connection(
@@ -1608,7 +1644,7 @@ class MultiTenantStore(BaseStore):
         project_domain_name = default_swift_reference.get(
             'project_domain_name')
 
-        if self.backend_group:
+        if self.backend_group and not self._url_prefix:
             self._set_url_prefix(context=context)
 
         # create client for multitenant user(trustor)

--- a/glance_store/driver.py
+++ b/glance_store/driver.py
@@ -89,6 +89,11 @@ class Store(capabilities.StoreCapability):
     def url_prefix(self):
         return self._url_prefix
 
+    def matches_uri(self, uri, context=None):
+        """Check if this store can handle the given location URI."""
+        return self._url_prefix is not None and uri.startswith(
+            self._url_prefix)
+
     @property
     def weight(self):
         if self.backend_group is None:

--- a/glance_store/tests/unit/test_store_base.py
+++ b/glance_store/tests/unit/test_store_base.py
@@ -15,6 +15,7 @@
 
 from unittest import mock
 
+import ddt
 from oslo_config import cfg
 
 import glance_store as store
@@ -24,6 +25,7 @@ from glance_store import multi_backend
 from glance_store.tests import base
 
 
+@ddt.ddt
 class TestStoreBase(base.StoreBaseTest):
 
     def setUp(self):
@@ -42,6 +44,23 @@ class TestStoreBase(base.StoreBaseTest):
                 "could not be configured correctly. Reason: Specify "
                 "at least 'filesystem_store_datadir' or "
                 "'filesystem_store_datadirs' option Disabling add method.")
+
+    @ddt.data(
+        # (prefix, uri, expected)
+        # No prefix set
+        (None, 'swift+https://host/path', False),
+        # Prefix matches
+        ('swift+https://host:8080/',
+         'swift+https://host:8080/v1/AUTH_t/container_id/id', True),
+        # Prefix mismatches
+        ('swift+https://host1:8080/',
+         'swift+https://host2:8080/v1/AUTH_t/container_id/id', False),
+    )
+    @ddt.unpack
+    def test_matches_uri(self, prefix, uri, expected):
+        s = store.driver.Store(mock.MagicMock())
+        s._url_prefix = prefix
+        self.assertEqual(expected, s.matches_uri(uri))
 
 
 class TestMultiStoreBase(base.MultiStoreBaseTest):

--- a/glance_store/tests/unit/test_swift_store_multibackend.py
+++ b/glance_store/tests/unit/test_swift_store_multibackend.py
@@ -18,6 +18,7 @@
 import copy
 from unittest import mock
 
+import ddt
 import fixtures
 import hashlib
 import http.client
@@ -61,6 +62,7 @@ SWIFT_CONF = {'swift_store_auth_address': 'localhost:8080',
               }
 
 
+@ddt.ddt
 class SwiftTests(object):
 
     def mock_keystone_client(self):
@@ -1027,6 +1029,58 @@ class SwiftTests(object):
         expected_url_prefix = "swift+config://ref1/glance/"
         self.assertEqual(expected_url_prefix, self.store.url_prefix)
 
+    @ddt.data(
+        # (endpoint, expected_prefix)
+        ('https://swift.example.com/v1', 'swift+https://swift.example.com/'),
+        (None, None),
+    )
+    @ddt.unpack
+    def test_multi_tenant_set_url_prefix(self, endpoint, expected_prefix):
+        self.config(group="swift1", swift_store_endpoint=endpoint)
+        mt_store = swift.MultiTenantStore(self.conf, backend="swift1")
+        mt_store.configure()
+        self.assertEqual(expected_prefix, mt_store.url_prefix)
+
+    @ddt.data(
+        # (uri, with_context, expected)
+        # Matching URI with context
+        ('swift+https://some_endpoint/v1/AUTH_t/glance_img-id/img-id',
+         True, True),
+        # Wrong container prefix
+        ('swift+https://some_endpoint/v1/AUTH_t/other_img-id/img-id',
+         True, False),
+        # Wrong netloc
+        ('swift+https://other_host/v1/AUTH_t/glance_img-id/img-id',
+         True, False),
+        # Wrong scheme
+        ('swift+http://some_endpoint/v1/AUTH_t/glance_img-id/img-id',
+         True, False),
+        # No context — falls back to get_schemes() + container prefix
+        ('swift+https://any_host/v1/AUTH_t/glance_img-id/img-id',
+         False, True),
+        # Too few path segments
+        ('swift+https://some_endpoint/only_one_segment',
+         True, False),
+    )
+    @ddt.unpack
+    def test_multi_tenant_matches_uri(self, uri, with_context, expected):
+        mt_store = swift.MultiTenantStore(self.conf, backend='swift1')
+        mt_store.configure()
+        ctxt = None
+        if with_context:
+            ctxt = mock.MagicMock(
+                user='user', tenant='tenant', auth_token='123',
+                service_catalog=[{
+                    'endpoint_links': [],
+                    'endpoints': [{
+                        'region': 'RegionOne',
+                        'publicURL': 'https://some_endpoint',
+                    }],
+                    'type': 'object-store',
+                    'name': 'Object Storage Service',
+                }])
+        self.assertEqual(expected, mt_store.matches_uri(uri, context=ctxt))
+
     def test_add_already_existing(self):
         """
         Tests that adding an image with an existing identifier
@@ -1404,6 +1458,7 @@ class SwiftTests(object):
         self.assertEqual(main_client, client)
 
 
+@ddt.ddt
 class TestStoreAuthV3(base.MultiStoreBaseTest, SwiftTests,
                       test_store_capabilities.TestStoreCapabilitiesChecking):
 
@@ -2040,6 +2095,8 @@ class TestCreatingLocations(base.MultiStoreBaseTest):
         self.ctxt.service_catalog[0]['endpoints'][0]['region'] = 'WestCarolina'
         self.assertEqual('https://some_endpoint',
                          store._get_endpoint(self.ctxt))
+        self.assertEqual('swift+https', store.scheme)
+        self.assertEqual('some_endpoint', store._storage_netloc)
 
     def test_multi_tenant_location_custom_service_type(self):
         self.config(group="swift1", swift_store_service_type='toy-store')
@@ -2049,6 +2106,8 @@ class TestCreatingLocations(base.MultiStoreBaseTest):
         store._get_endpoint(self.ctxt)
         self.assertEqual('https://some_endpoint',
                          store._get_endpoint(self.ctxt))
+        self.assertEqual('swift+https', store.scheme)
+        self.assertEqual('some_endpoint', store._storage_netloc)
 
     def test_multi_tenant_location_custom_endpoint_type(self):
         self.config(group="swift1", swift_store_endpoint_type='internalURL')
@@ -2056,6 +2115,8 @@ class TestCreatingLocations(base.MultiStoreBaseTest):
         store.configure()
         self.assertEqual('https://some_internal_endpoint',
                          store._get_endpoint(self.ctxt))
+        self.assertEqual('swift+https', store.scheme)
+        self.assertEqual('some_internal_endpoint', store._storage_netloc)
 
 
 class TestChunkReader(base.MultiStoreBaseTest):


### PR DESCRIPTION
`MultiTenantStore._set_url_prefix()` produced a malformed `url_prefix`, i.e.:
`swift+https://https://<host>:<port>/v1/AUTH_<project>:<container_>`.

It did not strip the http(s) scheme from the endpoint and used ":" instead of "/" as a separator after the `AUTH_<project>`. Additionally, `AUTH_<project>` is project-specific and consequently not a prefix of all the location URLs managed by the store.

This caused `_get_store_id_from_uri()` in glance to not match multi-tenant Swift stores in multi-backend setups. Since `url_prefix` was set via `init_client` and not at configure time like other stores, `_get_store_id_from_uri()` could be called without the prefix being set at all.

We fix this by:
- Reducing the store's `url_prefix` to `scheme://<host>:<port>/` and attempting to set it at configuration time via `configure_add` using `conf_endpoint`
- Adding a new function `matches_uri(uri, context)` to the base `Store` class which returns True if the store handles the URI. This allows to implement more complex pattern matching for `_get_store_id_from_uri` without implementing driver-specific matching logic in glance itself. The default implementation in the base class uses the existing prefix check from `_get_store_id_from_uri`.
- Swift's `MultiTenantStore` URLs have a fixed container `<container_>` infix that is not part of the `url_prefix`. Additionally, `matches_uri` may be called before the scheme, host and port are known. We therefore override `matches_uri` to perform best-effort matching based on the container and if available also the scheme and host:port (netloc).