### PR TITLE
Update [swift] store.py - change public ACL to support ceph

### DIFF
--- a/glance_store/_drivers/swift/store.py
+++ b/glance_store/_drivers/swift/store.py
@@ -1568,9 +1568,8 @@ class MultiTenantStore(BaseStore):
         headers = {}
         if public:
             if self.backend_group:
-                        pub_acl = getattr(
-                            self.conf,
-                            self.backend_group).swift_store_public_acl
+                pub_acl = getattr(self.conf,
+                                  self.backend_group).swift_store_public_acl
             else:
                 pub_acl = self.conf.glance_store.swift_store_public_acl
             headers['X-Container-Read'] = pub_acl

--- a/glance_store/_drivers/swift/store.py
+++ b/glance_store/_drivers/swift/store.py
@@ -477,7 +477,7 @@ read access and enables container listings, which is appropriate for
 standard Swift deployments.
 
 For Ceph Object Gateway (RGW) deployments, you may need to use
-``*.*`` instead, as RGW does not support the ``.r:*`` syntax.
+``.r:*,.rlistings`` instead, of ``*:*`` as RGW does not support the syntax.
 
 Possible values:
     * ``*:*`` (standard Swift — default)
@@ -1567,7 +1567,12 @@ class MultiTenantStore(BaseStore):
 
         headers = {}
         if public:
-            pub_acl = self.conf.glance_store.swift_store_public_acl
+            if self.backend_group:
+                        pub_acl = getattr(
+                            self.conf,
+                            self.backend_group).swift_store_public_acl
+            else:
+                pub_acl = self.conf.glance_store.swift_store_public_acl
             headers['X-Container-Read'] = pub_acl
         elif read_tenants:
             headers['X-Container-Read'] = ','.join('%s:*' % i

--- a/glance_store/_drivers/swift/store.py
+++ b/glance_store/_drivers/swift/store.py
@@ -466,6 +466,28 @@ Related options:
     * swift_upload_buffer_dir
 
 """),
+    cfg.StrOpt('swift_store_public_acl',
+               default='*:*',
+               help="""
+ACL string to set on Swift containers when an image is made public.
+
+This value is set as the ``X-Container-Read`` header when a public
+ACL is applied via ``set_acls()``. The default value grants anonymous
+read access and enables container listings, which is appropriate for
+standard Swift deployments.
+
+For Ceph Object Gateway (RGW) deployments, you may need to use
+``*.*`` instead, as RGW does not support the ``.r:*`` syntax.
+
+Possible values:
+    * ``*:*`` (standard Swift — default)
+    * ``.r:*,.rlistings`` (Ceph Object Gateway / RGW)
+    * Any valid Swift container read ACL string
+
+Related options:
+    * swift_store_multi_tenant
+
+"""),
 ]
 
 
@@ -1545,7 +1567,8 @@ class MultiTenantStore(BaseStore):
 
         headers = {}
         if public:
-            headers['X-Container-Read'] = "*:*"
+            pub_acl = self.conf.glance_store.swift_store_public_acl
+            headers['X-Container-Read'] = pub_acl
         elif read_tenants:
             headers['X-Container-Read'] = ','.join('%s:*' % i
                                                    for i in read_tenants)

--- a/glance_store/tests/unit/test_opts.py
+++ b/glance_store/tests/unit/test_opts.py
@@ -129,6 +129,7 @@ class OptsTestCase(base.StoreBaseTest):
             'swift_store_large_object_size',
             'swift_store_multi_tenant',
             'swift_store_multiple_containers_seed',
+            'swift_store_public_acl',
             'swift_store_region',
             'swift_store_retry_get_count',
             'swift_store_service_type',

--- a/glance_store/tests/unit/test_swift_store.py
+++ b/glance_store/tests/unit/test_swift_store.py
@@ -1262,7 +1262,7 @@ class SwiftTests(object):
 
     def test_read_acl_public(self):
         """
-        Test that we can set a public read acl.
+        Test that we can set a public read acl (default ACL value).
         """
         self.config(swift_store_config_file=None)
         self.config(swift_store_multi_tenant=True)
@@ -1274,7 +1274,25 @@ class SwiftTests(object):
         store.set_acls(loc, public=True, context=ctxt)
         container_headers = swiftclient.client.head_container('x', 'y',
                                                               'glance')
-        self.assertEqual("*:*", container_headers['X-Container-Read'])
+        self.assertEqual("*:*",
+                         container_headers['X-Container-Read'])
+
+    def test_read_acl_public_custom(self):
+        """
+        Test that a custom swift_store_public_acl is used when set.
+        """
+        self.config(swift_store_config_file=None)
+        self.config(swift_store_multi_tenant=True)
+        self.config(swift_store_public_acl='.r:*,.rlistings')
+        store = Store(self.conf)
+        store.configure()
+        uri = "swift+http://storeurl/glance/%s" % FAKE_UUID
+        loc = location.get_location_from_uri(uri, conf=self.conf)
+        ctxt = mock.MagicMock()
+        store.set_acls(loc, public=True, context=ctxt)
+        container_headers = swiftclient.client.head_container('x', 'y',
+                                                              'glance')
+        self.assertEqual('.r:*,.rlistings', container_headers['X-Container-Read'])
 
     def test_read_acl_tenants(self):
         """

--- a/glance_store/tests/unit/test_swift_store.py
+++ b/glance_store/tests/unit/test_swift_store.py
@@ -1292,7 +1292,8 @@ class SwiftTests(object):
         store.set_acls(loc, public=True, context=ctxt)
         container_headers = swiftclient.client.head_container('x', 'y',
                                                               'glance')
-        self.assertEqual('.r:*,.rlistings', container_headers['X-Container-Read'])
+        self.assertEqual('.r:*,.rlistings',
+                         container_headers['X-Container-Read'])
 
     def test_read_acl_tenants(self):
         """

--- a/glance_store/tests/unit/test_swift_store_multibackend.py
+++ b/glance_store/tests/unit/test_swift_store_multibackend.py
@@ -1293,7 +1293,27 @@ class SwiftTests(object):
         store.set_acls(loc, public=True, context=ctxt)
         container_headers = swiftclient.client.head_container('x', 'y',
                                                               'glance')
-        self.assertEqual("*:*", container_headers['X-Container-Read'])
+        self.assertEqual("*:*",
+                         container_headers['X-Container-Read'])
+
+    def test_read_acl_public_custom(self):
+        """
+        Test that a custom public acl is used when set.
+        """
+        self.config(group="swift1", swift_store_config_file=None)
+        self.config(group="swift1", swift_store_multi_tenant=True)
+        self.config(group="swift1", swift_store_public_acl='.r:*,.rlistings')
+        store = Store(self.conf, backend="swift1")
+        store.configure()
+        uri = "swift+http://storeurl/glance/%s" % FAKE_UUID
+        loc = location.get_location_from_uri_and_backend(
+            uri, "swift1", conf=self.conf)
+        ctxt = mock.MagicMock()
+        store.set_acls(loc, public=True, context=ctxt)
+        container_headers = swiftclient.client.head_container('x', 'y',
+                                                              'glance')
+        self.assertEqual('.r:*,.rlistings',
+                         container_headers['X-Container-Read'])
 
     def test_read_acl_tenants(self):
         """


### PR DESCRIPTION
Ceph currently handles `*:*` wrong, only the tokens from the image owner project are accepted, but originally the goal would be to accept any vaild openstack token. This change makes the files public readable without the need for token validation